### PR TITLE
Add plugin-based data orchestration framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Data-Sentinel
+
+Data-Sentinel provides a pluggable orchestration framework for building
+simple data workflows. The order of execution is defined in a JSON
+configuration file.
+
+## Example usage
+
+```bash
+python -m data_sentinel.run example_config.json
+```

--- a/data_sentinel/__init__.py
+++ b/data_sentinel/__init__.py
@@ -1,0 +1,5 @@
+"""Pluggable data workflow orchestration."""
+
+from .orchestrator import Orchestrator, load_config
+
+__all__ = ["Orchestrator", "load_config"]

--- a/data_sentinel/base.py
+++ b/data_sentinel/base.py
@@ -1,0 +1,19 @@
+class BaseModule:
+    """Base class for all pipeline modules."""
+
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+
+    def run(self, data):
+        """Run the module's logic.
+
+        Parameters
+        ----------
+        data : Any
+            Data passed from the previous stage.
+        Returns
+        -------
+        Any
+            Data to be passed to the next stage.
+        """
+        raise NotImplementedError

--- a/data_sentinel/modules/dq.py
+++ b/data_sentinel/modules/dq.py
@@ -1,0 +1,11 @@
+from ..base import BaseModule
+
+
+class DataQualityModule(BaseModule):
+    """Simple data quality check that ensures input is not empty."""
+
+    def run(self, data):
+        if not data:
+            raise ValueError("Received empty data")
+        # Return data unchanged for this placeholder
+        return data

--- a/data_sentinel/modules/readers.py
+++ b/data_sentinel/modules/readers.py
@@ -1,0 +1,17 @@
+from ..base import BaseModule
+
+
+class RealTimeReader(BaseModule):
+    """Example real-time reader returning static data."""
+
+    def run(self, data=None):
+        return {"records": [1, 2, 3]}
+
+
+class S3Reader(BaseModule):
+    """Example S3 reader (placeholder implementation)."""
+
+    def run(self, data=None):
+        bucket = self.config.get("bucket")
+        key = self.config.get("key")
+        return {"source": f"s3://{bucket}/{key}"}

--- a/data_sentinel/orchestrator.py
+++ b/data_sentinel/orchestrator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Iterable, List
+
+from .base import BaseModule
+
+
+class Orchestrator:
+    """Pipeline orchestrator that loads and runs configured modules."""
+
+    def __init__(self, stages: Iterable[dict]):
+        self.stages: List[BaseModule] = []
+        for stage_conf in stages:
+            module_path = stage_conf["module"]
+            config = stage_conf.get("config", {})
+            module_name, class_name = module_path.rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            cls = getattr(module, class_name)
+            if not issubclass(cls, BaseModule):
+                raise TypeError(f"{module_path} is not a BaseModule")
+            self.stages.append(cls(config))
+
+    def run(self) -> Any:
+        data: Any = None
+        for stage in self.stages:
+            data = stage.run(data)
+        return data
+
+
+def load_config(path: str | Path) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+    return cfg.get("pipeline", [])

--- a/data_sentinel/run.py
+++ b/data_sentinel/run.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from .orchestrator import Orchestrator, load_config
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("Usage: python -m data_sentinel.run <config_file>")
+        raise SystemExit(1)
+    config_file = Path(argv[0])
+    stages = load_config(config_file)
+    orchestrator = Orchestrator(stages)
+    result = orchestrator.run()
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/example_config.json
+++ b/example_config.json
@@ -1,0 +1,12 @@
+{
+  "pipeline": [
+    {
+      "module": "data_sentinel.modules.readers.RealTimeReader",
+      "config": {}
+    },
+    {
+      "module": "data_sentinel.modules.dq.DataQualityModule",
+      "config": {}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a pluggable orchestration framework in `data_sentinel`
- implement example Reader and Data Quality modules
- provide a runner entry point
- add an example configuration file
- document usage in README

## Testing
- `find data_sentinel -name '*.py' -print | xargs python -m py_compile`
- `python -m data_sentinel.run example_config.json`

------
https://chatgpt.com/codex/tasks/task_e_685b81ca2e44832d92ef121dca60cb19