### PR TITLE
Add pydantic models and stage options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,22 @@
 
 Data-Sentinel provides a pluggable orchestration framework for building
 simple data workflows. The order of execution is defined in a JSON
-configuration file.
+configuration file validated using Pydantic models. Each stage of the
+pipeline can receive its own configuration options.
 
 ## Example usage
 
 ```bash
 python -m data_sentinel.run example_config.json
+```
+
+The configuration file contains a list of stages with optional parameters:
+
+```json
+{
+  "pipeline": [
+    {"module": "data_sentinel.modules.readers.RealTimeReader", "config": {"records": [4, 5, 6]}},
+    {"module": "data_sentinel.modules.dq.DataQualityModule", "config": {"allow_empty": false}}
+  ]
+}
 ```

--- a/data_sentinel/__init__.py
+++ b/data_sentinel/__init__.py
@@ -1,5 +1,6 @@
 """Pluggable data workflow orchestration."""
 
 from .orchestrator import Orchestrator, load_config
+from .config import PipelineConfig, StageConfig
 
-__all__ = ["Orchestrator", "load_config"]
+__all__ = ["Orchestrator", "load_config", "PipelineConfig", "StageConfig"]

--- a/data_sentinel/config.py
+++ b/data_sentinel/config.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+
+class StageConfig(BaseModel):
+    """Configuration for a single pipeline stage."""
+
+    module: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PipelineConfig(BaseModel):
+    """Top level configuration schema."""
+
+    pipeline: List[StageConfig]

--- a/data_sentinel/modules/dq.py
+++ b/data_sentinel/modules/dq.py
@@ -5,7 +5,8 @@ class DataQualityModule(BaseModule):
     """Simple data quality check that ensures input is not empty."""
 
     def run(self, data):
-        if not data:
+        allow_empty = self.config.get("allow_empty", False)
+        if not allow_empty and not data:
             raise ValueError("Received empty data")
         # Return data unchanged for this placeholder
         return data

--- a/data_sentinel/modules/readers.py
+++ b/data_sentinel/modules/readers.py
@@ -5,7 +5,8 @@ class RealTimeReader(BaseModule):
     """Example real-time reader returning static data."""
 
     def run(self, data=None):
-        return {"records": [1, 2, 3]}
+        records = self.config.get("records", [1, 2, 3])
+        return {"records": records}
 
 
 class S3Reader(BaseModule):

--- a/data_sentinel/orchestrator.py
+++ b/data_sentinel/orchestrator.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import importlib
-import json
 from pathlib import Path
 from typing import Any, Iterable, List
+
+from .config import PipelineConfig, StageConfig
 
 from .base import BaseModule
 
@@ -11,11 +12,11 @@ from .base import BaseModule
 class Orchestrator:
     """Pipeline orchestrator that loads and runs configured modules."""
 
-    def __init__(self, stages: Iterable[dict]):
+    def __init__(self, stages: Iterable[StageConfig]):
         self.stages: List[BaseModule] = []
         for stage_conf in stages:
-            module_path = stage_conf["module"]
-            config = stage_conf.get("config", {})
+            module_path = stage_conf.module
+            config = stage_conf.config
             module_name, class_name = module_path.rsplit(".", 1)
             module = importlib.import_module(module_name)
             cls = getattr(module, class_name)
@@ -30,7 +31,7 @@ class Orchestrator:
         return data
 
 
-def load_config(path: str | Path) -> list[dict]:
-    with open(path, "r", encoding="utf-8") as fh:
-        cfg = json.load(fh)
-    return cfg.get("pipeline", [])
+def load_config(path: str | Path) -> list[StageConfig]:
+    """Load and validate configuration file."""
+    cfg = PipelineConfig.parse_file(path)
+    return cfg.pipeline

--- a/example_config.json
+++ b/example_config.json
@@ -2,11 +2,15 @@
   "pipeline": [
     {
       "module": "data_sentinel.modules.readers.RealTimeReader",
-      "config": {}
+      "config": {"records": [4, 5, 6]}
     },
     {
       "module": "data_sentinel.modules.dq.DataQualityModule",
-      "config": {}
+      "config": {"allow_empty": false}
+    },
+    {
+      "module": "data_sentinel.modules.readers.S3Reader",
+      "config": {"bucket": "my-bucket", "key": "path/to/key"}
     }
   ]
 }


### PR DESCRIPTION
## Summary
- introduce `StageConfig` and `PipelineConfig` based on Pydantic
- adapt orchestrator to use typed configuration
- allow modules to consume options from stage configs
- update example configuration and README

## Testing
- `python -m data_sentinel.run example_config.json`
- `python - <<'EOF'
from data_sentinel import load_config, Orchestrator
cfg = load_config('example_config.json')
print(cfg)
orc = Orchestrator(cfg)
print(orc.run())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685b9fd8df1c832d8e093625aaddee8f